### PR TITLE
Fix: fix perfcounter.json and exec file in the same directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -28,7 +29,8 @@ type PushConfig struct {
 }
 
 var (
-	configFn     = "./perfcounter.json"
+	configFile   = "perfcounter.json"
+	configFn     = "./" + configFile
 	defaultTags  = ""
 	defaultStep  = int64(60) //time in sec
 	defaultBases = []string{}
@@ -50,9 +52,15 @@ func config() *GlobalConfig {
 
 func loadConfig() error {
 	if !isFileExist(configFn) {
-		return fmt.Errorf("config file not found: %s", configFn)
+		execPath, err := filepath.Abs(filepath.Dir(os.Args[0]))
+		if err != nil {
+			return fmt.Errorf("get exec path err: %s", err.Error())
+		}
+		configFn = filepath.Join(execPath, configFile)
+		if !isFileExist(configFn) {
+			return fmt.Errorf("config file not found: %s", configFn)
+		}
 	}
-
 	c, err := parseConfig(configFn)
 	if err != nil {
 		return err

--- a/version.go
+++ b/version.go
@@ -1,7 +1,10 @@
 package goperfcounter
 
 // changelog:
+
+// 0.0.2: Fix perfcounter.json and exec file in the same directory
+
 // 0.0.1: init project
 const (
-	VERSION = "0.0.1"
+	VERSION = "0.0.2"
 )


### PR DESCRIPTION
目前获取perfcounter.json文件的路径是在运行golang二进制文件时shell所在目录，而不是“配置文件必须和golang二进制文件应用文件，在同一目录”。
现在修改为先获取“运行golang二进制文件时shell所在目录”，如果不存在，再从golang二进制文件应用文件目录获取